### PR TITLE
bugfix wrong line number reporting

### DIFF
--- a/stack.go
+++ b/stack.go
@@ -116,7 +116,7 @@ func Callers(skip int) Stack {
 	stack := make(Stack, num)
 	for i, pc := range pcs[:num] {
 		fun := runtime.FuncForPC(pc)
-		file, line := fun.FileLine(pc)
+		file, line := fun.FileLine(pc - 1)
 		stack[i].File = StripGOPATH(file)
 		stack[i].Line = line
 		stack[i].Name = StripPackage(fun.Name())

--- a/stack_test.go
+++ b/stack_test.go
@@ -48,7 +48,7 @@ func TestCallersMultiWithTwo(t *testing.T) {
 		"",
 		"",
 		`\(Stack 2\)$`,
-		"stack_test.go:46 +TestCallersMultiWithTwo$",
+		"stack_test.go:45 +TestCallersMultiWithTwo$",
 	}
 	match(t, m.String(), matches)
 }


### PR DESCRIPTION
The bug occured when using _stack_ with _ensure_ which always reported the next instruction as failing instruction.

According to 
https://golang.org/src/runtime/extern.go?s=8754:8794#L169

> Note that since each slice entry pc[i] is a return program counter, looking up the file and line for pc[i](for example, using %28*Func%29.FileLine) will return the file and line number of the instruction immediately following the call. To look up the file and line number of the call itself, use pc[i]-1. As an exception to this rule, if pc[i-1] corresponds to the function runtime.sigpanic, then pc[i] is the program counter of a faulting instruction and should be used without any subtraction.

The correct line is now reported but I'm not sure how to check for runtime.sigpanic as function origin.
